### PR TITLE
feat: add custom css prop

### DIFF
--- a/src/h5p.vue
+++ b/src/h5p.vue
@@ -55,6 +55,10 @@ export default {
       type: Boolean,
       default: false
     },
+    customCss: {
+      type: String,
+      default: ''
+    },
     l10n: {
       type: Object,
       default: () => ({})
@@ -127,7 +131,7 @@ export default {
 <html class="h5p-iframe">
   <head>
     <base target="_parent">
-    <style>${frameStyle}</style>
+    <style>${frameStyle} ${this.customCss}</style>
     ${contentStyles}
     <script>H5PIntegration = ${JSON.stringify(h5pIntegration)};var H5P = H5P || {};H5P.externalEmbed = true;${endScript}
     <script>${frameScript}${endScript}

--- a/tests/unit/__snapshots__/h5p.spec.js.snap
+++ b/tests/unit/__snapshots__/h5p.spec.js.snap
@@ -342,6 +342,7 @@ exports[`Component iframe passes props 1`] = `
     <base target="_parent">
     <style>
       /* MOCKED_FRAME_CSS */
+      /* MOCKED_CUSTOM_CSS */
     </style>
     <link rel="stylesheet" href="/hello-world/H5P.GreetingCard-1.0/greetingcard.css">
     <script>

--- a/tests/unit/h5p.spec.js
+++ b/tests/unit/h5p.spec.js
@@ -139,6 +139,7 @@ describe('Component', () => {
         export: '/export/url',
         embed: '<iframe></iframe>',
         fullscreen: true,
+        customCss: '/* MOCKED_CUSTOM_CSS */',
         copyright: true,
         icon: true,
         resize: 'resize code'


### PR DESCRIPTION
This feature request makes it possible to pass custom styles to overwrite native H5P-styles. I ran into a problem when trying to hide/show the fullscreen button which is shown even when the fullscreen prop is set to false.

With this prop styles like the background-color, hide/show certain elements, width & height etc. can be adjusted or even bound to variables.