### PR TITLE
feat: `css` prop for custom style injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,18 +60,19 @@ export default {
 
 The component accepts the following props:
 
-|Prop           | Required | Type          | Default | Description|
-|---------------|----------|---------------|---------|------------|
-|src            |yes       |String         |-        |Path to the h5p content|
-|l10n           |no        |Object         |{}       |UI translations|
-|embed          |no        |String         |''       |Set embedCode and enable embed button|
-|resize         |no        |String         |''       |Set resizeCode|
-|export         |no        |String         |''       |Set exportUrl and enable export button|
-|copyright      |no        |Boolean        |false    |Enable copyright button|
-|icon           |no        |Boolean        |false    |Enable H5P icon|
-|fullscreen     |no        |Boolean        |false    |Enable fullscreen button|
+| Prop       | Required | Type    | Default | Description                             |
+| ---------- | -------- | ------- | ------- | --------------------------------------- |
+| copyright  | no       | Boolean | false   | Enable copyright button                 |
+| css        | no       | String  | ''      | Inject css into a <style> in the iframe |
+| embed      | no       | String  | ''      | Set embedCode and enable embed button   |
+| export     | no       | String  | ''      | Set exportUrl and enable export button  |
+| fullscreen | no       | Boolean | false   | Enable fullscreen button                |
+| icon       | no       | Boolean | false   | Enable H5P icon                         |
+| l10n       | no       | Object  | {}      | UI translations                         |
+| resize     | no       | String  | ''      | Set resizeCode                          |
+| src        | yes      | String  | -       | Path to the h5p content                 |
 
-See https://h5p.org/creating-your-own-h5p-plugin for translation strings.
+See [Creating your own h5p plugin](https://h5p.org/creating-your-own-h5p-plugin) for translation strings.
 
 NOTE: UI translations are not reactive. You have to manually trigger a rerender for translation changes to take effect (e.g. by binding :key to your locale).
 
@@ -84,6 +85,21 @@ All events emitted by H5P are emitted by vue-h5p, event names are the H5P [event
 You can use the default slot to render a placeholder while the content is loading.
 
 The named slot "error" is rendered if a request to get the h5p JSON files fails, the slot-scope provides failed request as "error" object.
+
+### Custom CSS
+
+You can inject custom CSS into the H5P iframe by using the `css` prop.
+
+```html
+<h5p
+  src="path/to/h5p-content"
+  :css="`
+    .class-in-the-iframe {
+      background-color: #fff;
+    }
+  `"
+/>
+```
 
 ## Development
 

--- a/example/Example.vue
+++ b/example/Example.vue
@@ -14,6 +14,7 @@
       :key="locale"
       src="/h5p/"
       :l10n="translations[locale]"
+      :styles="styles"
       icon
       copyright
       export="true"
@@ -44,7 +45,13 @@ export default {
           reuse: 'Wiederverwenden',
           reuseContent: 'Content Wiederverwenden'
         }
-      }
+      },
+      styles: `
+        .h5p-chart .h5p-chart-chart {
+          background-color: cadetblue;
+          padding: 15px;
+        }
+      `
     }
   },
   methods: {

--- a/src/h5p.vue
+++ b/src/h5p.vue
@@ -55,6 +55,10 @@ export default {
       type: Boolean,
       default: false
     },
+    css: {
+      type: String,
+      default: ''
+    },
     l10n: {
       type: Object,
       default: () => ({})
@@ -134,6 +138,7 @@ export default {
     <base target="_parent">
     <style>${frameStyle}</style>
     ${contentStyles}
+    <style>${this.css}</style>
     <script>H5PIntegration = ${JSON.stringify(h5pIntegration)};var H5P = H5P || {};H5P.externalEmbed = true;${endScript}
     <script>${frameScript}${endScript}
     ${contentScripts}

--- a/tests/unit/__snapshots__/h5p.spec.js.snap
+++ b/tests/unit/__snapshots__/h5p.spec.js.snap
@@ -10,6 +10,7 @@ exports[`Component iframe has correct attribute srcdoc 1`] = `
       /* MOCKED_FRAME_CSS */
     </style>
     <link rel="stylesheet" href="/hello-world/H5P.GreetingCard-1.0/greetingcard.css">
+    <style></style>
     <script>
       H5PIntegration = {
         "l10n": {
@@ -158,6 +159,7 @@ exports[`Component iframe has sorted dependencies 1`] = `
     <link rel="stylesheet" href="/course-presentation/H5P.DragText-1.8/dist/h5p-drag-text.css">
     <link rel="stylesheet" href="/course-presentation/H5P.MultiChoice-1.14/css/multichoice.css">
     <link rel="stylesheet" href="/course-presentation/H5P.CoursePresentation-1.21/dist/h5p-course-presentation.css">
+    <style></style>
     <script>
       H5PIntegration = {
         "l10n": {
@@ -344,6 +346,9 @@ exports[`Component iframe passes props 1`] = `
       /* MOCKED_FRAME_CSS */
     </style>
     <link rel="stylesheet" href="/hello-world/H5P.GreetingCard-1.0/greetingcard.css">
+    <style>
+      /* MOCKED_USER_STYLE_CSS */
+    </style>
     <script>
       H5PIntegration = {
         "l10n": {
@@ -467,6 +472,7 @@ exports[`Component iframe without version in library paths 1`] = `
       /* MOCKED_FRAME_CSS */
     </style>
     <link rel="stylesheet" href="/hello-world-no-version/H5P.GreetingCard/greetingcard.css">
+    <style></style>
     <script>
       H5PIntegration = {
         "l10n": {

--- a/tests/unit/h5p.spec.js
+++ b/tests/unit/h5p.spec.js
@@ -140,6 +140,7 @@ describe('Component', () => {
         embed: '<iframe></iframe>',
         fullscreen: true,
         copyright: true,
+        css: '/* MOCKED_USER_STYLE_CSS */',
         icon: true,
         resize: 'resize code',
         integration: {


### PR DESCRIPTION
This PR creates an `styles` prop that makes it possible to inject customs styles into the H5P iframe.