### PR TITLE
Add metadata when existing

### DIFF
--- a/src/h5p.vue
+++ b/src/h5p.vue
@@ -125,6 +125,9 @@ export default {
       ),
       ...this.integration
     }
+    if (h5p && h5p.title) {
+      h5pIntegration.contents['cid-default'].metadata = h5p
+    }
 
     const { styles, scripts } = this.sortDependencies(libraries)
 


### PR DESCRIPTION
This change will allow to load an [Interactive Book](https://h5p.org/content-types/interactive-book) (use the example from h5p.org to test)
Without this line the h5p plugin is returning the error `contentData.metadata.title` is not defined.
Sending the content of the file h5p.json as `metadata` property in the default content fixes this problem