### PR TITLE
fix: iframe styles are missing

### DIFF
--- a/src/h5p.vue
+++ b/src/h5p.vue
@@ -1,11 +1,11 @@
 <template>
-  <div :class="$style.fullSize">
+  <div>
     <iframe
       v-if="srcdoc"
       v-show="!loading"
       ref="iframe"
-      :class="$style.fullSize"
       :srcdoc="srcdoc"
+      style="width: 100%; height: 100%; border: none;"
       @load="addEventHandlers"
     />
     <template v-if="loading">
@@ -223,11 +223,3 @@ export default {
   }
 }
 </script>
-
-<style module>
-.full-size {
-  border: 0;
-  height: 100%;
-  width: 100%;
-}
-</style>

--- a/tests/unit/__snapshots__/h5p.spec.js.snap
+++ b/tests/unit/__snapshots__/h5p.spec.js.snap
@@ -621,7 +621,7 @@ exports[`Component renders default slot content while loading: should have defau
   <body>
     <div class=&quot;h5p-content&quot; data-content-id=&quot;default&quot;/>
   </body>
-</html>" style="display: none;"></iframe> hello from the DEFAULT slot</div>
+</html>" style="width: 100%; height: 100%; display: none;"></iframe> hello from the DEFAULT slot</div>
 `;
 
 exports[`Component renders default slot content while loading: should have only default slot content 1`] = `
@@ -645,7 +645,7 @@ exports[`Component renders default slot content while loading: should have only 
   <body>
     <div class=&quot;h5p-content&quot; data-content-id=&quot;default&quot;/>
   </body>
-</html>" style="display: none;"></iframe> hello from the DEFAULT slot</div>
+</html>" style="width: 100%; height: 100%; display: none;"></iframe> hello from the DEFAULT slot</div>
 `;
 
 exports[`Component renders error slot on fetch-errors and provides response object: should have error slot content 1`] = `


### PR DESCRIPTION
The styles set in the `<style>` block were not included in the build.

![image](https://user-images.githubusercontent.com/60694691/158656344-71c61b2b-7cd0-4615-9116-517dc44119b2.png)

While testing other options, I found out that H5P initial set the `h5p-wrapper` size based on the `iframe.width` and `iframe.height` these values don't take the `ComputedStyle()` of the iframe. 

This PR reverts the style changes in `0.5.1`

